### PR TITLE
Update SourcePattern

### DIFF
--- a/GrpcNativeLibsCopier.csproj
+++ b/GrpcNativeLibsCopier.csproj
@@ -17,7 +17,7 @@
 
     <!-- the native dll (grpc_csharp_ext.x64.dll) location may change between grpc.core updates -->
     <PropertyGroup>
-      <SourcePattern>$(NuGetPackageRoot)Grpc.Core\$(GrpcCoreVersion)**\runtimes\win\native\*.dll</SourcePattern>
+      <SourcePattern>$(NuGetPackageRoot)\Grpc.Core\$(GrpcCoreVersion)\runtimes\win-*\native\*.dll</SourcePattern>
     </PropertyGroup>
 
     <Message Importance="high" Text="Grpc.Core version: $(GrpcCoreVersion)" />


### PR DESCRIPTION
I'm using `Grpc.Core` (`2.36.0`) NuGet package in `PackageReference` -format. I had to slightly modify the `SourcePattern` to work:
* `$(NuGetPackageRoot)` has no trailing backslash in my case so i added one
*  The folder structure was slightly modified in the package so native Windows dependencies are now stored under `[...]\runtimes\win-x86\[...]` and  `[...]\runtimes\win-x64\[...]`